### PR TITLE
Fixed compatibility with kotlin 1.0.3

### DIFF
--- a/src/main/scala/KotlinCompile.scala
+++ b/src/main/scala/KotlinCompile.scala
@@ -79,7 +79,9 @@ object KotlinReflection {
     val servicesClass = cl.loadClass("org.jetbrains.kotlin.config.Services")
     val messageCollectorClass = cl.loadClass("org.jetbrains.kotlin.cli.common.messages.MessageCollector")
     val commonCompilerArgsClass = cl.loadClass("org.jetbrains.kotlin.cli.common.arguments.CommonCompilerArguments")
-    val argsClass = cl.loadClass("org.jetbrains.kotlin.relocated.com.sampullara.cli.Args")
+    val classesToTry = "org.jetbrains.kotlin.com.sampullara.cli.Args" :: "org.jetbrains.kotlin.relocated.com.sampullara.cli.Args" :: Nil
+    val argsClass = classesToTry.view.map(x => Try(cl.loadClass(x))).find(_.isSuccess)
+      .getOrElse(throw new MessageOnlyException("Unable to find Args class")).get
     // kotlin 1.0.2 bundles broken spullara:cli-args that removed Args.parse(Object,String[])
     val parseMethod = Try(argsClass.getMethod("parse", classOf[Object], classOf[Array[String]])).map(Left.apply).recoverWith {
       case _ =>

--- a/src/main/scala/KotlinPlugin.scala
+++ b/src/main/scala/KotlinPlugin.scala
@@ -42,7 +42,7 @@ object KotlinPlugin extends AutoPlugin {
           }
       }
     },
-    kotlinVersion := "1.0.2",
+    kotlinVersion := "1.0.3",
     kotlincOptions := Nil,
     kotlincPluginOptions := Nil,
     watchSources     <++= Def.task {


### PR DESCRIPTION
9544ffc - [relocation package was changed](https://github.com/JetBrains/kotlin/commit/23353facca88d18e4ef22dde17e6b6e28d9a9e1c#diff-f152446566264ed99feb6a8c69a30718R11), so the old one makes compilation failed
157d85a - as I understand, while 1.0.3, kotlin-compiler-embeddable is kotlin-android-extensions' (and maybe not only its) runtime dependency. Or maybe there is some more neat way to exclude it?
