### PR TITLE
Document how to disable version check

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Current version 1.0.7
   `kotlinVersion`
   plugin
 * `kotlincOptions`: options to pass to the kotlin compiler
+* `updateCheck in Kotlin := ()` in the root project disables the check version
+  for the latest version of this plugin
 
 ### Examples
 


### PR DESCRIPTION
The version check is annoying for multiple reasons (e.g. it looks like SBT is still loading since there is never a `> ` blank line).

I would suggest disabling it by default, or creating a separate plugin that can do this more generally for *all* dependencies.

More conservatively, it would be nice to document how to disable it.