### PR TITLE
Fix kotlin tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ Current version 1.0.8
   `kotlinVersion`
   plugin
 * `kotlincOptions`: options to pass to the kotlin compiler
-* `definedTests in Test := KotlinTest.kotlinTests.value`: specifies kotlin test classes
 
 ### Examples
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Current version 1.0.8
   `kotlinVersion`
   plugin
 * `kotlincOptions`: options to pass to the kotlin compiler
+* `definedTests in Test := KotlinTest.kotlinTests.value`: specifies kotlin test classes
 
 ### Examples
 

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ name := "kotlin-plugin"
 
 organization := "com.hanhuy.sbt"
 
-version := "1.0.8"
+version := "1.0.9-SNAPSHOT"
 
 scalacOptions ++= Seq("-deprecation","-Xlint","-feature")
 

--- a/src/main/scala/KotlinPlugin.scala
+++ b/src/main/scala/KotlinPlugin.scala
@@ -68,6 +68,7 @@ object KotlinPlugin extends AutoPlugin {
           classDirectory.value, streams.value)
     }.dependsOn (compileInputs in (Compile,compile)).value,
     compile := (compile dependsOn kotlinCompile).value,
-    kotlinSource := sourceDirectory.value / "kotlin"
+    kotlinSource := sourceDirectory.value / "kotlin",
+    definedTests in Test := KotlinTest.kotlinTests.value
   )
 }

--- a/src/main/scala/KotlinPlugin.scala
+++ b/src/main/scala/KotlinPlugin.scala
@@ -69,6 +69,6 @@ object KotlinPlugin extends AutoPlugin {
     }.dependsOn (compileInputs in (Compile,compile)).value,
     compile := (compile dependsOn kotlinCompile).value,
     kotlinSource := sourceDirectory.value / "kotlin",
-    definedTests in Test := KotlinTest.kotlinTests.value
+    definedTests in Test ++= KotlinTest.kotlinTests.value
   )
 }

--- a/src/main/scala/KotlinTest.scala
+++ b/src/main/scala/KotlinTest.scala
@@ -1,0 +1,41 @@
+package sbt
+
+import sbt.Keys._
+import sbt.classfile.Analyze
+import sbt.classpath.ClasspathUtilities
+import sbt.inc.{Analysis, IncOptions, IncrementalCompile}
+import xsbti.compile.SingleOutput
+
+object KotlinTest {
+  val kotlinTests = Def.task {
+    val old = (definedTests in Test).value
+    val out = ((target in Test).value ** "scala-*").get.head / "test-classes"
+    val srcs = ((sourceDirectory  in Test).value ** "*.kt").get.toList
+    val xs = (out ** "*.class").get.toList
+
+    val loader = ClasspathUtilities.toLoader((fullClasspath in Test).value map {
+      _.data
+    })
+    val log = sLog.value
+    val a0 = IncrementalCompile(
+      srcs.toSet, s => None,
+      (fs, changs, callback) => {
+        def readAPI(source: File, classes: Seq[Class[_]]): Set[String] = {
+          val (api, inherits) = ClassToAPI.process(classes)
+          callback.api(source, api)
+          inherits.map(_.getName)
+        }
+
+        Analyze(xs, srcs, log)(callback, loader, readAPI)
+      },
+      Analysis.Empty, f => None,
+      new SingleOutput {
+        def outputDirectory = out
+      },
+      log,
+      IncOptions.Default)._2
+    val frameworks = (loadedTestFrameworks in Test).value.values.toList
+    log.info(s"Compiling ${srcs.length} Kotlin source to ${out}...")
+    old ++ Tests.discover(frameworks, a0, log)._1
+  }
+}

--- a/src/main/scala/KotlinTest.scala
+++ b/src/main/scala/KotlinTest.scala
@@ -15,7 +15,7 @@ object KotlinTest {
     val loader = ClasspathUtilities.toLoader((fullClasspath in Test).value map {
       _.data
     })
-    val log = sLog.value
+    val log = streams.value.log
     val a0 = IncrementalCompile(
       srcs.toSet, s => None,
       (fs, changs, callback) => {

--- a/src/main/scala/KotlinTest.scala
+++ b/src/main/scala/KotlinTest.scala
@@ -8,7 +8,6 @@ import xsbti.compile.SingleOutput
 
 object KotlinTest {
   val kotlinTests = Def.task {
-    val old = (definedTests in Test).value
     val out = ((target in Test).value ** "scala-*").get.head / "test-classes"
     val srcs = ((sourceDirectory  in Test).value ** "*.kt").get.toList
     val xs = (out ** "*.class").get.toList
@@ -36,6 +35,6 @@ object KotlinTest {
       IncOptions.Default)._2
     val frameworks = (loadedTestFrameworks in Test).value.values.toList
     log.info(s"Compiling ${srcs.length} Kotlin source to ${out}...")
-    old ++ Tests.discover(frameworks, a0, log)._1
+    Tests.discover(frameworks, a0, log)._1
   }
 }

--- a/src/sbt-test/kotlin/basic-tests/build.sbt
+++ b/src/sbt-test/kotlin/basic-tests/build.sbt
@@ -1,0 +1,5 @@
+kotlinLib("stdlib")
+
+libraryDependencies ++= Seq(
+  "com.novocode" % "junit-interface" % "0.11" % Test
+)

--- a/src/sbt-test/kotlin/basic-tests/build.sbt
+++ b/src/sbt-test/kotlin/basic-tests/build.sbt
@@ -1,5 +1,27 @@
+import sbt.complete.Parsers.spaceDelimited
+
+import scala.xml.{NodeSeq, XML}
+
 kotlinLib("stdlib")
 
 libraryDependencies ++= Seq(
   "com.novocode" % "junit-interface" % "0.11" % Test
 )
+
+lazy val checkTestPass = inputKey[Unit]("Check if a given test-report has one success test")
+checkTestPass := {
+  val args: Seq[String] = spaceDelimited("<arg>").parsed
+  val testName = args.head
+
+  val xml = XML.load(s"target/test-reports/$testName.xml")
+  val totalTests = getInt(xml \\ "testsuite" \ "@tests")
+  val failures = getInt(xml \\ "testsuite" \ "@failures")
+  val errors = getInt(xml \\ "testsuite" \ "@errors")
+  val skipped = getInt(xml \\ "testsuite" \ "@skipped")
+
+  if (totalTests == 0 || failures > 0 || errors > 0 || skipped > 0) {
+    sys.error("Tests not passed")
+  }
+}
+
+def getInt(path: NodeSeq): Int = path.text.toInt

--- a/src/sbt-test/kotlin/basic-tests/project/plugins.sbt
+++ b/src/sbt-test/kotlin/basic-tests/project/plugins.sbt
@@ -1,0 +1,9 @@
+{
+  val ver = System.getProperty("plugin.version")
+  if (ver == null)
+    throw new RuntimeException("""
+                                 |The system property 'plugin.version' is not defined.
+                                 |Specify this property using scriptedLaunchOpts -Dplugin.version."""
+      .stripMargin)
+  else addSbtPlugin("com.hanhuy.sbt" % "kotlin-plugin" % ver)
+}

--- a/src/sbt-test/kotlin/basic-tests/src/main/kotlin/simple.kt
+++ b/src/sbt-test/kotlin/basic-tests/src/main/kotlin/simple.kt
@@ -1,0 +1,6 @@
+package demo
+
+fun main(args: Array<String>) {
+  println("Hello, world!")
+}
+

--- a/src/sbt-test/kotlin/basic-tests/src/test/kotlin/SimpleTest.kt
+++ b/src/sbt-test/kotlin/basic-tests/src/test/kotlin/SimpleTest.kt
@@ -1,0 +1,11 @@
+import org.junit.Test
+import junit.framework.TestCase.assertEquals
+
+class SimpleTest {
+
+  @Test
+  fun `should works`() {
+    assertEquals(4, 2 + 2)
+  }
+
+}

--- a/src/sbt-test/kotlin/basic-tests/test
+++ b/src/sbt-test/kotlin/basic-tests/test
@@ -1,0 +1,3 @@
+> compile
+> test
+> "test-only *SimpleTest"

--- a/src/sbt-test/kotlin/basic-tests/test
+++ b/src/sbt-test/kotlin/basic-tests/test
@@ -1,3 +1,3 @@
 > compile
 > test
-> "test-only *SimpleTest"
+> "checkTestPass SimpleTest"

--- a/src/sbt-test/kotlin/mixed-tests/build.sbt
+++ b/src/sbt-test/kotlin/mixed-tests/build.sbt
@@ -1,0 +1,5 @@
+kotlinLib("stdlib")
+
+libraryDependencies ++= Seq(
+  "com.novocode" % "junit-interface" % "0.11" % Test
+)

--- a/src/sbt-test/kotlin/mixed-tests/build.sbt
+++ b/src/sbt-test/kotlin/mixed-tests/build.sbt
@@ -1,5 +1,27 @@
+import sbt.complete.Parsers.spaceDelimited
+
+import scala.xml.{NodeSeq, XML}
+
 kotlinLib("stdlib")
 
 libraryDependencies ++= Seq(
   "com.novocode" % "junit-interface" % "0.11" % Test
 )
+
+lazy val checkTestPass = inputKey[Unit]("Check if a given test-report has one success test")
+checkTestPass := {
+  val args: Seq[String] = spaceDelimited("<arg>").parsed
+  val testName = args.head
+
+  val xml = XML.load(s"target/test-reports/$testName.xml")
+  val totalTests = getInt(xml \\ "testsuite" \ "@tests")
+  val failures = getInt(xml \\ "testsuite" \ "@failures")
+  val errors = getInt(xml \\ "testsuite" \ "@errors")
+  val skipped = getInt(xml \\ "testsuite" \ "@skipped")
+
+  if (totalTests == 0 || failures > 0 || errors > 0 || skipped > 0) {
+    sys.error("Tests not passed")
+  }
+}
+
+def getInt(path: NodeSeq): Int = path.text.toInt

--- a/src/sbt-test/kotlin/mixed-tests/project/plugins.sbt
+++ b/src/sbt-test/kotlin/mixed-tests/project/plugins.sbt
@@ -1,0 +1,9 @@
+{
+  val ver = System.getProperty("plugin.version")
+  if (ver == null)
+    throw new RuntimeException("""
+                                 |The system property 'plugin.version' is not defined.
+                                 |Specify this property using scriptedLaunchOpts -Dplugin.version."""
+      .stripMargin)
+  else addSbtPlugin("com.hanhuy.sbt" % "kotlin-plugin" % ver)
+}

--- a/src/sbt-test/kotlin/mixed-tests/src/main/java/demo/JavaCalculator.java
+++ b/src/sbt-test/kotlin/mixed-tests/src/main/java/demo/JavaCalculator.java
@@ -1,0 +1,9 @@
+package demo;
+
+public class JavaCalculator {
+
+  public int sum(int a, int b) {
+    return a + b;
+  }
+
+}

--- a/src/sbt-test/kotlin/mixed-tests/src/main/kotlin/Calculator.kt
+++ b/src/sbt-test/kotlin/mixed-tests/src/main/kotlin/Calculator.kt
@@ -1,0 +1,7 @@
+package demo
+
+class Calculator(private val calculator: JavaCalculator) {
+
+  fun sum(a: Int, b: Int): Int = calculator.sum(a, b)
+
+}

--- a/src/sbt-test/kotlin/mixed-tests/src/test/kotlin/MixedTest.kt
+++ b/src/sbt-test/kotlin/mixed-tests/src/test/kotlin/MixedTest.kt
@@ -1,0 +1,14 @@
+import org.junit.Test
+import junit.framework.TestCase.assertEquals
+import demo.Calculator
+import demo.JavaCalculator
+
+class MixedTest {
+
+  @Test
+  fun `should sum 2 plus 2`() {
+    val calculator = Calculator(JavaCalculator())
+    assertEquals(4, calculator.sum(2, 2))
+  }
+
+}

--- a/src/sbt-test/kotlin/mixed-tests/test
+++ b/src/sbt-test/kotlin/mixed-tests/test
@@ -1,0 +1,3 @@
+> compile
+> test
+> "test-only *MixedTest"

--- a/src/sbt-test/kotlin/mixed-tests/test
+++ b/src/sbt-test/kotlin/mixed-tests/test
@@ -1,3 +1,3 @@
 > compile
 > test
-> "test-only *MixedTest"
+> "checkTestPass MixedTest"


### PR DESCRIPTION
#### Motivation

While using the plugin, we have found that when you run `sbt test` the plugin isn't able to find the test classes. This doesn't let us execute our test written in kotlin.

#### Implementation

I have added a KotlintTest class to find kotlin test classes, KotlinTest class should be located in the `sbt` package to access to some sbt protected objects and methods like `sbt.classfile.Analyze`

#### Usage

To be able to run the test using this plugin you only need to add the ` definedTests in Test := KotlinTest.kotlinTests.value` line in `build.sbt`.

```scala
lazy val `project-name` = (project in file("."))
  .settings(
    kotlinLib("stdlib"),
    definedTests in Test := KotlinTest.kotlinTests.value
  )
```