### PR TITLE
Fix Kotlin version compatibility tests

### DIFF
--- a/src/sbt-test/kotlin/kotlin-1.1-compat/test
+++ b/src/sbt-test/kotlin/kotlin-1.1-compat/test
@@ -1,3 +1,3 @@
 > compile
 > listClasses
-$ exists target/scala-2.10/classes/demo/SimpleKt.class
+$ exists target/scala-2.12/classes/demo/SimpleKt.class

--- a/src/sbt-test/kotlin/kotlin-1.2-compat/test
+++ b/src/sbt-test/kotlin/kotlin-1.2-compat/test
@@ -1,3 +1,3 @@
 > compile
 > listClasses
-$ exists target/scala-2.10/classes/demo/SimpleKt.class
+$ exists target/scala-2.12/classes/demo/SimpleKt.class

--- a/src/sbt-test/kotlin/kotlin-1.3-compat/test
+++ b/src/sbt-test/kotlin/kotlin-1.3-compat/test
@@ -1,3 +1,3 @@
 > compile
 > listClasses
-$ exists target/scala-2.10/classes/demo/SimpleKt.class
+$ exists target/scala-2.12/classes/demo/SimpleKt.class


### PR DESCRIPTION
Fixes a failure in the New Kotlin compatibility tests due to the old version of the plugin using Scala 2.10 but the new sbt 1.x version using Scala 2.12.