### PR TITLE
Fixes #31 - failed to compile .kts file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target/
+.idea

--- a/src/main/scala/KotlinPlugin.scala
+++ b/src/main/scala/KotlinPlugin.scala
@@ -19,9 +19,11 @@ object KotlinPlugin extends AutoPlugin {
   }) :: Nil
 
   override def projectSettings = Seq(
-    libraryDependencies += {
-      "org.jetbrains.kotlin" % "kotlin-compiler-embeddable" % kotlinVersion.value % KotlinInternal.name
-    },
+    libraryDependencies ++= Seq(
+      "org.jetbrains.kotlin" % "kotlin-compiler-embeddable" % kotlinVersion.value % KotlinInternal.name,
+      "org.jetbrains.kotlin" % "kotlin-scripting-compiler-embeddable" % kotlinVersion.value % KotlinInternal.name,
+      "org.jetbrains.kotlin" % "kotlin-scripting-compiler-embeddable" % kotlinVersion.value,
+  ),
     managedClasspath in KotlinInternal := Classpaths.managedJars(KotlinInternal, classpathTypes.value, update.value),
     updateCheck in Kotlin := {
       val log = streams.value.log

--- a/src/sbt-test/kotlin/mixed/src/main/kotlin/script.kts
+++ b/src/sbt-test/kotlin/mixed/src/main/kotlin/script.kts
@@ -1,0 +1,2 @@
+
+println("Hello from Kotlin script")

--- a/src/sbt-test/kotlin/mixed/tests.sbt
+++ b/src/sbt-test/kotlin/mixed/tests.sbt
@@ -1,7 +1,7 @@
 TaskKey[Unit]("check-classes") := {
   val classes = (classDirectory in Compile).value
   val classList = (classes ** "*.class").get
-  if (classList.size != 6) {
+  if (classList.size != 7) {
     throw new MessageOnlyException(s"Incorrect number of classes: ${classList.size} =>\n${classList.mkString("\n")}")
   }
 }


### PR DESCRIPTION
Compiling `.kts` file requires `kotlin-scripting-compiler-embeddable` dependency

Refer comment from this issue, https://youtrack.jetbrains.com/issue/KT-30679, which states
```
starting from 1.3.30, the scripting part is moved into compiler plugin. 
In your case most likely it will be enough to add kotlin-scripting-compiler with its dependencies to the classpath
```