### PR TITLE
Compile Kotlin scripts for versions of Kotlin < 1.3.30

### DIFF
--- a/src/main/scala/KotlinPlugin.scala
+++ b/src/main/scala/KotlinPlugin.scala
@@ -18,12 +18,25 @@ object KotlinPlugin extends AutoPlugin {
     Project.runTask(updateCheck in Keys.Kotlin, s).fold(s)(_._1)
   }) :: Nil
 
+  private def kotlinScriptCompilerDeps(kotlinVer: String) = {
+    import scala.math.Ordering.Implicits.infixOrderingOps
+
+    if (KotlinVersion(kotlinVer) <= KotlinVersion("1.3.21")) {
+      Seq(
+        "org.jetbrains.kotlin" % "kotlin-script-runtime" % kotlinVer
+      )
+    } else {
+      Seq(
+        "org.jetbrains.kotlin" % "kotlin-scripting-compiler-embeddable" % kotlinVer % KotlinInternal.name,
+        "org.jetbrains.kotlin" % "kotlin-scripting-compiler-embeddable" % kotlinVer
+      )
+    }
+  }
+
   override def projectSettings = Seq(
     libraryDependencies ++= Seq(
-      "org.jetbrains.kotlin" % "kotlin-compiler-embeddable" % kotlinVersion.value % KotlinInternal.name,
-      "org.jetbrains.kotlin" % "kotlin-scripting-compiler-embeddable" % kotlinVersion.value % KotlinInternal.name,
-      "org.jetbrains.kotlin" % "kotlin-scripting-compiler-embeddable" % kotlinVersion.value,
-  ),
+      "org.jetbrains.kotlin" % "kotlin-compiler-embeddable" % kotlinVersion.value % KotlinInternal.name
+    ) ++ kotlinScriptCompilerDeps(kotlinVersion.value),
     managedClasspath in KotlinInternal := Classpaths.managedJars(KotlinInternal, classpathTypes.value, update.value),
     updateCheck in Kotlin := {
       val log = streams.value.log

--- a/src/main/scala/KotlinVersion.scala
+++ b/src/main/scala/KotlinVersion.scala
@@ -1,0 +1,10 @@
+package kotlin
+
+import scala.math.Ordering
+
+case class KotlinVersion(versionString: String) extends AnyVal
+
+object KotlinVersion {
+  implicit val versionOrdering: Ordering[KotlinVersion] =
+    Ordering.by { _.versionString.split("[.-]").map(_.toInt).toIterable }
+}

--- a/src/sbt-test/kotlin/kotlin-1.1-compat/src/main/kotlin/SimpleScript.kts
+++ b/src/sbt-test/kotlin/kotlin-1.1-compat/src/main/kotlin/SimpleScript.kts
@@ -1,0 +1,1 @@
+println("Hello world!")

--- a/src/sbt-test/kotlin/kotlin-1.2-compat/src/main/kotlin/SimpleScript.kts
+++ b/src/sbt-test/kotlin/kotlin-1.2-compat/src/main/kotlin/SimpleScript.kts
@@ -1,0 +1,1 @@
+println("Hello world!")

--- a/src/sbt-test/kotlin/kotlin-1.2-compat/test
+++ b/src/sbt-test/kotlin/kotlin-1.2-compat/test
@@ -1,3 +1,4 @@
 > compile
 > listClasses
 $ exists target/scala-2.12/classes/demo/SimpleKt.class
+$ exists target/scala-2.12/classes/SimpleScript.class

--- a/src/sbt-test/kotlin/kotlin-1.3-compat/src/main/kotlin/SimpleScript.kts
+++ b/src/sbt-test/kotlin/kotlin-1.3-compat/src/main/kotlin/SimpleScript.kts
@@ -1,0 +1,1 @@
+println("Hello world!")

--- a/src/sbt-test/kotlin/kotlin-1.3-compat/test
+++ b/src/sbt-test/kotlin/kotlin-1.3-compat/test
@@ -1,3 +1,4 @@
 > compile
 > listClasses
 $ exists target/scala-2.12/classes/demo/SimpleKt.class
+$ exists target/scala-2.12/classes/SimpleScript.class

--- a/src/sbt-test/kotlin/kotlin-script/build.sbt
+++ b/src/sbt-test/kotlin/kotlin-script/build.sbt
@@ -1,0 +1,10 @@
+kotlinLib("stdlib")
+
+kotlinVersion := "1.3.21"
+
+val listClasses = taskKey[Unit]("listClasses")
+
+listClasses := {
+  val classes = (classDirectory in Compile).value.listFiles()
+  streams.value.log.info("classes: " + classes)
+}

--- a/src/sbt-test/kotlin/kotlin-script/project/build.properties
+++ b/src/sbt-test/kotlin/kotlin-script/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.2.8

--- a/src/sbt-test/kotlin/kotlin-script/project/plugins.sbt
+++ b/src/sbt-test/kotlin/kotlin-script/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.hanhuy.sbt" % "kotlin-plugin" % sys.props("plugin.version"))

--- a/src/sbt-test/kotlin/kotlin-script/src/main/kotlin/SimpleScript.kts
+++ b/src/sbt-test/kotlin/kotlin-script/src/main/kotlin/SimpleScript.kts
@@ -1,0 +1,1 @@
+println("Hello world!")

--- a/src/sbt-test/kotlin/kotlin-script/test
+++ b/src/sbt-test/kotlin/kotlin-script/test
@@ -1,4 +1,3 @@
 > compile
 > listClasses
-$ exists target/scala-2.12/classes/demo/SimpleKt.class
 $ exists target/scala-2.12/classes/SimpleScript.class


### PR DESCRIPTION
The fix for compiling Kotlin scripts works great for 1.3.30+, but doesn't work for earlier versions of Kotlin which require a different dependency.

Checks the Kotlin version and adds an older dependency for script compilation if the version is 1.3.21 or below, or the newer dependency if the version is above 1.3.21.