### PR TITLE
Add settingKey for changing jvm-target parameter

### DIFF
--- a/src/main/scala/Keys.scala
+++ b/src/main/scala/Keys.scala
@@ -21,6 +21,8 @@ object Keys {
     "version of kotlin to use for building")
   val kotlincOptions = SettingKey[Seq[String]]("kotlinc-options",
     "options to pass to the kotlin compiler")
+  val kotlincJvmTarget = SettingKey[String]("kotlinc-jvm-target",
+    "jvm target to use for building")
 
   def kotlinLib(name: String) = sbt.Keys.libraryDependencies +=
     "org.jetbrains.kotlin" % ("kotlin-" + name) % kotlinVersion.value

--- a/src/main/scala/KotlinCompile.scala
+++ b/src/main/scala/KotlinCompile.scala
@@ -26,6 +26,7 @@ object KotlinCompile {
     KotlinReflection.fromClasspath(cp))
 
   def compile(options: Seq[String],
+              jvmTarget: String,
               sourceDirs: Seq[File],
               kotlinPluginOptions: Seq[String],
               classpath: Classpath,
@@ -53,7 +54,7 @@ object KotlinCompile {
       s.log.info(message)
       args.freeArgs = (kotlinSources ++ javaSources.map(_._1)).map(_.getAbsolutePath).asJava
       args.noStdlib = true
-
+      args.jvmTarget = jvmTarget
       val fcpjars = classpath.map(_.data.getAbsoluteFile)
       val (pluginjars, cpjars) = fcpjars.partition {
         grepjar(_)(_.getName.startsWith(

--- a/src/main/scala/KotlinPlugin.scala
+++ b/src/main/scala/KotlinPlugin.scala
@@ -57,6 +57,7 @@ object KotlinPlugin extends AutoPlugin {
       }
     },
     kotlinVersion := "1.3.50",
+    kotlincJvmTarget := "1.6",
     kotlincOptions := Nil,
     kotlincPluginOptions := Nil,
     watchSources     ++= {
@@ -74,9 +75,11 @@ object KotlinPlugin extends AutoPlugin {
   val kotlinCompileSettings = List(
     unmanagedSourceDirectories += kotlinSource.value,
     kotlincOptions := kotlincOptions.value,
+    kotlincJvmTarget := kotlincJvmTarget.value,
     kotlincPluginOptions := kotlincPluginOptions.value,
     kotlinCompile := Def.task {
         KotlinCompile.compile(kotlincOptions.value,
+          kotlincJvmTarget.value,
           sourceDirectories.value, kotlincPluginOptions.value,
           dependencyClasspath.value, (managedClasspath in KotlinInternal).value,
           classDirectory.value, streams.value)


### PR DESCRIPTION
Since this cannot be set using the `kotlincOptions` I have added a `SettingKey` for changing the target JVM of the kotlin compiler.