### PR TITLE
Publishable version with Kotlin 1.2.x and 1.3.x on sbt 0.13.x

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ name := "kotlin-plugin"
 
 organization := "com.hanhuy.sbt"
 
-version := "1.0.10-SNAPSHOT"
+version := "1.0.10"
 
 scalacOptions ++= Seq("-deprecation","-Xlint","-feature")
 


### PR DESCRIPTION
For those needing Kotlin 1.2+ running on 0.13.x sbt projects.